### PR TITLE
make cal0blank = 1 in sysmmc

### DIFF
--- a/bootloader/ini/more_configs.ini
+++ b/bootloader/ini/more_configs.ini
@@ -1,7 +1,7 @@
 [Semi Stock]
 fss0=atmosphere/package3
 emummc_force_disable=1
-cal0blank=0
+cal0blank=1
 kip1=atmosphere/kips/*
 logopath=bootloader/res/bootscreen.bmp
 icon=bootloader/res/sys_cfw_nobox.bmp
@@ -9,7 +9,7 @@ icon=bootloader/res/sys_cfw_nobox.bmp
 [Semi Safe]
 fss0=atmosphere/package3
 emummc_force_disable=1
-cal0blank=0
+cal0blank=1
 logopath=bootloader/res/bootscreen.bmp
 icon=bootloader/res/sys_sm_nobox.bmp
 


### PR DESCRIPTION
Since `cal0blank = 0` Overrides Exosphère config `blank_prodinfo_{sys/emu}mmc`, setting `blank_prodinfo_sysmmc = 1` in Ultra-NX [`exosphere.ini`](https://github.com/Ultra-NX/UltraNX/blob/main/exosphere.ini) becomes meaningless. Therefore, I change `cal0bank = 1` to hide info